### PR TITLE
M4 simplify ground truth tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ unsuccessfulbuild
 *.DS_Store
 
 # Paths to Data Directories
-*Detection_Algorithm/Data/Video/
+*Detection_Algorithm/Data/Video/*/*/*.mp4
+*Detection_Algorithm/Data/Video/*/*.mp4
 *Detection_Algorithm/Data/Extracted_Frames/

--- a/Detection_Algorithm/Data/Video/Mercy/Glock/firing.meta
+++ b/Detection_Algorithm/Data/Video/Mercy/Glock/firing.meta
@@ -1,0 +1,2055 @@
+1, Mercy, No Action
+2, Mercy, No Action
+3, Mercy, No Action
+4, Mercy, No Action
+5, Mercy, No Action
+6, Mercy, No Action
+7, Mercy, No Action
+8, Mercy, No Action
+9, Mercy, No Action
+10, Mercy, No Action
+11, Mercy, No Action
+12, Mercy, No Action
+13, Mercy, No Action
+14, Mercy, No Action
+15, Mercy, No Action
+16, Mercy, No Action
+17, Mercy, No Action
+18, Mercy, No Action
+19, Mercy, No Action
+20, Mercy, No Action
+21, Mercy, No Action
+22, Mercy, No Action
+23, Mercy, No Action
+24, Mercy, No Action
+25, Mercy, No Action
+26, Mercy, No Action
+27, Mercy, No Action
+28, Mercy, No Action
+29, Mercy, No Action
+30, Mercy, Firing
+31, Mercy, Firing
+32, Mercy, Firing
+33, Mercy, Firing
+34, Mercy, Firing
+35, Mercy, No Action
+36, Mercy, No Action
+37, Mercy, No Action
+38, Mercy, No Action
+39, Mercy, No Action
+40, Mercy, No Action
+41, Mercy, No Action
+42, Mercy, No Action
+43, Mercy, No Action
+44, Mercy, No Action
+45, Mercy, No Action
+46, Mercy, No Action
+47, Mercy, No Action
+48, Mercy, No Action
+49, Mercy, No Action
+50, Mercy, No Action
+51, Mercy, No Action
+52, Mercy, No Action
+53, Mercy, No Action
+54, Mercy, No Action
+55, Mercy, No Action
+56, Mercy, No Action
+57, Mercy, No Action
+58, Mercy, No Action
+59, Mercy, No Action
+60, Mercy, No Action
+61, Mercy, No Action
+62, Mercy, No Action
+63, Mercy, No Action
+64, Mercy, No Action
+65, Mercy, No Action
+66, Mercy, No Action
+67, Mercy, No Action
+68, Mercy, Firing
+69, Mercy, Firing
+70, Mercy, Firing
+71, Mercy, Firing
+72, Mercy, Firing
+73, Mercy, No Action
+74, Mercy, No Action
+75, Mercy, No Action
+76, Mercy, No Action
+77, Mercy, No Action
+78, Mercy, No Action
+79, Mercy, No Action
+80, Mercy, No Action
+81, Mercy, No Action
+82, Mercy, No Action
+83, Mercy, No Action
+84, Mercy, No Action
+85, Mercy, No Action
+86, Mercy, No Action
+87, Mercy, No Action
+88, Mercy, No Action
+89, Mercy, No Action
+90, Mercy, No Action
+91, Mercy, No Action
+92, Mercy, No Action
+93, Mercy, No Action
+94, Mercy, No Action
+95, Mercy, No Action
+96, Mercy, No Action
+97, Mercy, No Action
+98, Mercy, No Action
+99, Mercy, No Action
+100, Mercy, No Action
+101, Mercy, No Action
+102, Mercy, No Action
+103, Mercy, No Action
+104, Mercy, No Action
+105, Mercy, No Action
+106, Mercy, No Action
+107, Mercy, No Action
+108, Mercy, No Action
+109, Mercy, No Action
+110, Mercy, No Action
+111, Mercy, No Action
+112, Mercy, Firing
+113, Mercy, Firing
+114, Mercy, Firing
+115, Mercy, Firing
+116, Mercy, Firing
+117, Mercy, No Action
+118, Mercy, No Action
+119, Mercy, No Action
+120, Mercy, No Action
+121, Mercy, No Action
+122, Mercy, No Action
+123, Mercy, No Action
+124, Mercy, No Action
+125, Mercy, No Action
+126, Mercy, No Action
+127, Mercy, No Action
+128, Mercy, No Action
+129, Mercy, No Action
+130, Mercy, No Action
+131, Mercy, No Action
+132, Mercy, No Action
+133, Mercy, No Action
+134, Mercy, No Action
+135, Mercy, No Action
+136, Mercy, No Action
+137, Mercy, No Action
+138, Mercy, No Action
+139, Mercy, No Action
+140, Mercy, No Action
+141, Mercy, No Action
+142, Mercy, No Action
+143, Mercy, No Action
+144, Mercy, No Action
+145, Mercy, No Action
+146, Mercy, No Action
+147, Mercy, No Action
+148, Mercy, No Action
+149, Mercy, No Action
+150, Mercy, No Action
+151, Mercy, No Action
+152, Mercy, No Action
+153, Mercy, No Action
+154, Mercy, No Action
+155, Mercy, No Action
+156, Mercy, No Action
+157, Mercy, Firing
+158, Mercy, Firing
+159, Mercy, Firing
+160, Mercy, Firing
+161, Mercy, Firing
+162, Mercy, No Action
+163, Mercy, No Action
+164, Mercy, No Action
+165, Mercy, No Action
+166, Mercy, No Action
+167, Mercy, No Action
+168, Mercy, No Action
+169, Mercy, No Action
+170, Mercy, No Action
+171, Mercy, No Action
+172, Mercy, No Action
+173, Mercy, No Action
+174, Mercy, No Action
+175, Mercy, No Action
+176, Mercy, No Action
+177, Mercy, No Action
+178, Mercy, No Action
+179, Mercy, No Action
+180, Mercy, No Action
+181, Mercy, No Action
+182, Mercy, No Action
+183, Mercy, No Action
+184, Mercy, No Action
+185, Mercy, No Action
+186, Mercy, No Action
+187, Mercy, No Action
+188, Mercy, No Action
+189, Mercy, No Action
+190, Mercy, No Action
+191, Mercy, No Action
+192, Mercy, No Action
+193, Mercy, No Action
+194, Mercy, No Action
+195, Mercy, No Action
+196, Mercy, No Action
+197, Mercy, No Action
+198, Mercy, No Action
+199, Mercy, No Action
+200, Mercy, No Action
+201, Mercy, No Action
+202, Mercy, No Action
+203, Mercy, No Action
+204, Mercy, No Action
+205, Mercy, Firing
+206, Mercy, Firing
+207, Mercy, Firing
+208, Mercy, Firing
+209, Mercy, Firing
+210, Mercy, No Action
+211, Mercy, No Action
+212, Mercy, No Action
+213, Mercy, No Action
+214, Mercy, No Action
+215, Mercy, No Action
+216, Mercy, No Action
+217, Mercy, No Action
+218, Mercy, No Action
+219, Mercy, No Action
+220, Mercy, No Action
+221, Mercy, No Action
+222, Mercy, No Action
+223, Mercy, No Action
+224, Mercy, No Action
+225, Mercy, No Action
+226, Mercy, No Action
+227, Mercy, No Action
+228, Mercy, No Action
+229, Mercy, No Action
+230, Mercy, No Action
+231, Mercy, No Action
+232, Mercy, No Action
+233, Mercy, No Action
+234, Mercy, No Action
+235, Mercy, No Action
+236, Mercy, No Action
+237, Mercy, No Action
+238, Mercy, No Action
+239, Mercy, No Action
+240, Mercy, No Action
+241, Mercy, No Action
+242, Mercy, No Action
+243, Mercy, No Action
+244, Mercy, No Action
+245, Mercy, No Action
+246, Mercy, No Action
+247, Mercy, No Action
+248, Mercy, No Action
+249, Mercy, No Action
+250, Mercy, No Action
+251, Mercy, No Action
+252, Mercy, No Action
+253, Mercy, No Action
+254, Mercy, No Action
+255, Mercy, No Action
+256, Mercy, No Action
+257, Mercy, No Action
+258, Mercy, No Action
+259, Mercy, Firing
+260, Mercy, Firing
+261, Mercy, Firing
+262, Mercy, Firing
+263, Mercy, Firing
+264, Mercy, No Action
+265, Mercy, No Action
+266, Mercy, No Action
+267, Mercy, No Action
+268, Mercy, No Action
+269, Mercy, No Action
+270, Mercy, No Action
+271, Mercy, No Action
+272, Mercy, No Action
+273, Mercy, No Action
+274, Mercy, No Action
+275, Mercy, No Action
+276, Mercy, No Action
+277, Mercy, No Action
+278, Mercy, No Action
+279, Mercy, No Action
+280, Mercy, No Action
+281, Mercy, No Action
+282, Mercy, No Action
+283, Mercy, No Action
+284, Mercy, No Action
+285, Mercy, No Action
+286, Mercy, No Action
+287, Mercy, No Action
+288, Mercy, No Action
+289, Mercy, No Action
+290, Mercy, No Action
+291, Mercy, No Action
+292, Mercy, No Action
+293, Mercy, No Action
+294, Mercy, No Action
+295, Mercy, No Action
+296, Mercy, No Action
+297, Mercy, No Action
+298, Mercy, No Action
+299, Mercy, No Action
+300, Mercy, No Action
+301, Mercy, No Action
+302, Mercy, No Action
+303, Mercy, No Action
+304, Mercy, No Action
+305, Mercy, No Action
+306, Mercy, No Action
+307, Mercy, Firing
+308, Mercy, Firing
+309, Mercy, Firing
+310, Mercy, Firing
+311, Mercy, Firing
+312, Mercy, No Action
+313, Mercy, No Action
+314, Mercy, No Action
+315, Mercy, No Action
+316, Mercy, No Action
+317, Mercy, No Action
+318, Mercy, No Action
+319, Mercy, No Action
+320, Mercy, No Action
+321, Mercy, No Action
+322, Mercy, No Action
+323, Mercy, No Action
+324, Mercy, No Action
+325, Mercy, No Action
+326, Mercy, No Action
+327, Mercy, No Action
+328, Mercy, No Action
+329, Mercy, No Action
+330, Mercy, No Action
+331, Mercy, No Action
+332, Mercy, No Action
+333, Mercy, No Action
+334, Mercy, No Action
+335, Mercy, No Action
+336, Mercy, No Action
+337, Mercy, No Action
+338, Mercy, No Action
+339, Mercy, No Action
+340, Mercy, No Action
+341, Mercy, No Action
+342, Mercy, No Action
+343, Mercy, No Action
+344, Mercy, No Action
+345, Mercy, No Action
+346, Mercy, No Action
+347, Mercy, No Action
+348, Mercy, No Action
+349, Mercy, No Action
+350, Mercy, No Action
+351, Mercy, No Action
+352, Mercy, No Action
+353, Mercy, No Action
+354, Mercy, No Action
+355, Mercy, Firing
+356, Mercy, Firing
+357, Mercy, Firing
+358, Mercy, Firing
+359, Mercy, Firing
+360, Mercy, No Action
+361, Mercy, No Action
+362, Mercy, No Action
+363, Mercy, No Action
+364, Mercy, No Action
+365, Mercy, No Action
+366, Mercy, No Action
+367, Mercy, No Action
+368, Mercy, No Action
+369, Mercy, No Action
+370, Mercy, No Action
+371, Mercy, No Action
+372, Mercy, No Action
+373, Mercy, No Action
+374, Mercy, No Action
+375, Mercy, No Action
+376, Mercy, No Action
+377, Mercy, No Action
+378, Mercy, No Action
+379, Mercy, No Action
+380, Mercy, No Action
+381, Mercy, No Action
+382, Mercy, No Action
+383, Mercy, No Action
+384, Mercy, No Action
+385, Mercy, No Action
+386, Mercy, No Action
+387, Mercy, No Action
+388, Mercy, No Action
+389, Mercy, No Action
+390, Mercy, No Action
+391, Mercy, No Action
+392, Mercy, No Action
+393, Mercy, No Action
+394, Mercy, No Action
+395, Mercy, No Action
+396, Mercy, No Action
+397, Mercy, No Action
+398, Mercy, No Action
+399, Mercy, No Action
+400, Mercy, No Action
+401, Mercy, No Action
+402, Mercy, No Action
+403, Mercy, No Action
+404, Mercy, No Action
+405, Mercy, No Action
+406, Mercy, No Action
+407, Mercy, No Action
+408, Mercy, No Action
+409, Mercy, No Action
+410, Mercy, Firing
+411, Mercy, Firing
+412, Mercy, Firing
+413, Mercy, Firing
+414, Mercy, Firing
+415, Mercy, No Action
+416, Mercy, No Action
+417, Mercy, No Action
+418, Mercy, No Action
+419, Mercy, No Action
+420, Mercy, No Action
+421, Mercy, No Action
+422, Mercy, No Action
+423, Mercy, No Action
+424, Mercy, No Action
+425, Mercy, No Action
+426, Mercy, No Action
+427, Mercy, No Action
+428, Mercy, No Action
+429, Mercy, No Action
+430, Mercy, No Action
+431, Mercy, No Action
+432, Mercy, No Action
+433, Mercy, No Action
+434, Mercy, No Action
+435, Mercy, No Action
+436, Mercy, No Action
+437, Mercy, No Action
+438, Mercy, No Action
+439, Mercy, No Action
+440, Mercy, No Action
+441, Mercy, No Action
+442, Mercy, No Action
+443, Mercy, No Action
+444, Mercy, No Action
+445, Mercy, No Action
+446, Mercy, No Action
+447, Mercy, No Action
+448, Mercy, No Action
+449, Mercy, No Action
+450, Mercy, No Action
+451, Mercy, No Action
+452, Mercy, No Action
+453, Mercy, No Action
+454, Mercy, No Action
+455, Mercy, No Action
+456, Mercy, No Action
+457, Mercy, No Action
+458, Mercy, No Action
+459, Mercy, No Action
+460, Mercy, No Action
+461, Mercy, No Action
+462, Mercy, Firing
+463, Mercy, Firing
+464, Mercy, Firing
+465, Mercy, Firing
+466, Mercy, Firing
+467, Mercy, No Action
+468, Mercy, No Action
+469, Mercy, No Action
+470, Mercy, No Action
+471, Mercy, No Action
+472, Mercy, No Action
+473, Mercy, No Action
+474, Mercy, No Action
+475, Mercy, No Action
+476, Mercy, No Action
+477, Mercy, No Action
+478, Mercy, No Action
+479, Mercy, No Action
+480, Mercy, No Action
+481, Mercy, No Action
+482, Mercy, No Action
+483, Mercy, No Action
+484, Mercy, No Action
+485, Mercy, No Action
+486, Mercy, No Action
+487, Mercy, No Action
+488, Mercy, No Action
+489, Mercy, No Action
+490, Mercy, No Action
+491, Mercy, No Action
+492, Mercy, No Action
+493, Mercy, No Action
+494, Mercy, No Action
+495, Mercy, No Action
+496, Mercy, No Action
+497, Mercy, No Action
+498, Mercy, No Action
+499, Mercy, No Action
+500, Mercy, No Action
+501, Mercy, No Action
+502, Mercy, No Action
+503, Mercy, No Action
+504, Mercy, No Action
+505, Mercy, No Action
+506, Mercy, No Action
+507, Mercy, No Action
+508, Mercy, Firing
+509, Mercy, Firing
+510, Mercy, Firing
+511, Mercy, Firing
+512, Mercy, Firing
+513, Mercy, No Action
+514, Mercy, No Action
+515, Mercy, No Action
+516, Mercy, No Action
+517, Mercy, No Action
+518, Mercy, No Action
+519, Mercy, No Action
+520, Mercy, No Action
+521, Mercy, No Action
+522, Mercy, No Action
+523, Mercy, No Action
+524, Mercy, No Action
+525, Mercy, No Action
+526, Mercy, No Action
+527, Mercy, No Action
+528, Mercy, No Action
+529, Mercy, No Action
+530, Mercy, No Action
+531, Mercy, No Action
+532, Mercy, No Action
+533, Mercy, No Action
+534, Mercy, No Action
+535, Mercy, No Action
+536, Mercy, No Action
+537, Mercy, No Action
+538, Mercy, No Action
+539, Mercy, No Action
+540, Mercy, No Action
+541, Mercy, No Action
+542, Mercy, No Action
+543, Mercy, No Action
+544, Mercy, No Action
+545, Mercy, No Action
+546, Mercy, No Action
+547, Mercy, No Action
+548, Mercy, No Action
+549, Mercy, No Action
+550, Mercy, No Action
+551, Mercy, No Action
+552, Mercy, No Action
+553, Mercy, No Action
+554, Mercy, No Action
+555, Mercy, Firing
+556, Mercy, Firing
+557, Mercy, Firing
+558, Mercy, Firing
+559, Mercy, Firing
+560, Mercy, No Action
+561, Mercy, No Action
+562, Mercy, No Action
+563, Mercy, No Action
+564, Mercy, No Action
+565, Mercy, No Action
+566, Mercy, No Action
+567, Mercy, No Action
+568, Mercy, No Action
+569, Mercy, No Action
+570, Mercy, No Action
+571, Mercy, No Action
+572, Mercy, No Action
+573, Mercy, No Action
+574, Mercy, No Action
+575, Mercy, No Action
+576, Mercy, No Action
+577, Mercy, No Action
+578, Mercy, No Action
+579, Mercy, No Action
+580, Mercy, No Action
+581, Mercy, No Action
+582, Mercy, No Action
+583, Mercy, No Action
+584, Mercy, No Action
+585, Mercy, No Action
+586, Mercy, No Action
+587, Mercy, No Action
+588, Mercy, No Action
+589, Mercy, No Action
+590, Mercy, No Action
+591, Mercy, No Action
+592, Mercy, No Action
+593, Mercy, No Action
+594, Mercy, No Action
+595, Mercy, No Action
+596, Mercy, No Action
+597, Mercy, No Action
+598, Mercy, No Action
+599, Mercy, No Action
+600, Mercy, No Action
+601, Mercy, No Action
+602, Mercy, No Action
+603, Mercy, No Action
+604, Mercy, No Action
+605, Mercy, No Action
+606, Mercy, No Action
+607, Mercy, No Action
+608, Mercy, No Action
+609, Mercy, No Action
+610, Mercy, No Action
+611, Mercy, No Action
+612, Mercy, No Action
+613, Mercy, No Action
+614, Mercy, No Action
+615, Mercy, No Action
+616, Mercy, No Action
+617, Mercy, No Action
+618, Mercy, No Action
+619, Mercy, No Action
+620, Mercy, No Action
+621, Mercy, No Action
+622, Mercy, No Action
+623, Mercy, No Action
+624, Mercy, No Action
+625, Mercy, No Action
+626, Mercy, No Action
+627, Mercy, No Action
+628, Mercy, No Action
+629, Mercy, No Action
+630, Mercy, No Action
+631, Mercy, No Action
+632, Mercy, No Action
+633, Mercy, No Action
+634, Mercy, No Action
+635, Mercy, No Action
+636, Mercy, No Action
+637, Mercy, No Action
+638, Mercy, No Action
+639, Mercy, No Action
+640, Mercy, No Action
+641, Mercy, No Action
+642, Mercy, No Action
+643, Mercy, No Action
+644, Mercy, No Action
+645, Mercy, No Action
+646, Mercy, No Action
+647, Mercy, No Action
+648, Mercy, No Action
+649, Mercy, No Action
+650, Mercy, No Action
+651, Mercy, No Action
+652, Mercy, No Action
+653, Mercy, No Action
+654, Mercy, No Action
+655, Mercy, No Action
+656, Mercy, No Action
+657, Mercy, No Action
+658, Mercy, No Action
+659, Mercy, No Action
+660, Mercy, No Action
+661, Mercy, No Action
+662, Mercy, No Action
+663, Mercy, No Action
+664, Mercy, No Action
+665, Mercy, No Action
+666, Mercy, No Action
+667, Mercy, No Action
+668, Mercy, No Action
+669, Mercy, No Action
+670, Mercy, No Action
+671, Mercy, No Action
+672, Mercy, No Action
+673, Mercy, No Action
+674, Mercy, No Action
+675, Mercy, No Action
+676, Mercy, No Action
+677, Mercy, No Action
+678, Mercy, No Action
+679, Mercy, No Action
+680, Mercy, No Action
+681, Mercy, No Action
+682, Mercy, No Action
+683, Mercy, Firing
+684, Mercy, Firing
+685, Mercy, Firing
+686, Mercy, Firing
+687, Mercy, Firing
+688, Mercy, No Action
+689, Mercy, No Action
+690, Mercy, No Action
+691, Mercy, No Action
+692, Mercy, No Action
+693, Mercy, No Action
+694, Mercy, No Action
+695, Mercy, No Action
+696, Mercy, No Action
+697, Mercy, No Action
+698, Mercy, No Action
+699, Mercy, No Action
+700, Mercy, No Action
+701, Mercy, No Action
+702, Mercy, No Action
+703, Mercy, No Action
+704, Mercy, No Action
+705, Mercy, No Action
+706, Mercy, No Action
+707, Mercy, No Action
+708, Mercy, No Action
+709, Mercy, No Action
+710, Mercy, No Action
+711, Mercy, No Action
+712, Mercy, No Action
+713, Mercy, No Action
+714, Mercy, No Action
+715, Mercy, No Action
+716, Mercy, No Action
+717, Mercy, No Action
+718, Mercy, No Action
+719, Mercy, No Action
+720, Mercy, No Action
+721, Mercy, No Action
+722, Mercy, No Action
+723, Mercy, No Action
+724, Mercy, No Action
+725, Mercy, No Action
+726, Mercy, No Action
+727, Mercy, Firing
+728, Mercy, Firing
+729, Mercy, Firing
+730, Mercy, Firing
+731, Mercy, Firing
+732, Mercy, No Action
+733, Mercy, No Action
+734, Mercy, No Action
+735, Mercy, No Action
+736, Mercy, No Action
+737, Mercy, No Action
+738, Mercy, No Action
+739, Mercy, No Action
+740, Mercy, No Action
+741, Mercy, No Action
+742, Mercy, No Action
+743, Mercy, No Action
+744, Mercy, No Action
+745, Mercy, No Action
+746, Mercy, No Action
+747, Mercy, No Action
+748, Mercy, No Action
+749, Mercy, No Action
+750, Mercy, No Action
+751, Mercy, No Action
+752, Mercy, No Action
+753, Mercy, No Action
+754, Mercy, No Action
+755, Mercy, No Action
+756, Mercy, No Action
+757, Mercy, No Action
+758, Mercy, No Action
+759, Mercy, No Action
+760, Mercy, No Action
+761, Mercy, No Action
+762, Mercy, No Action
+763, Mercy, No Action
+764, Mercy, No Action
+765, Mercy, No Action
+766, Mercy, No Action
+767, Mercy, No Action
+768, Mercy, No Action
+769, Mercy, No Action
+770, Mercy, No Action
+771, Mercy, No Action
+772, Mercy, No Action
+773, Mercy, No Action
+774, Mercy, No Action
+775, Mercy, No Action
+776, Mercy, No Action
+777, Mercy, No Action
+778, Mercy, No Action
+779, Mercy, No Action
+780, Mercy, Firing
+781, Mercy, Firing
+782, Mercy, Firing
+783, Mercy, Firing
+784, Mercy, Firing
+785, Mercy, No Action
+786, Mercy, No Action
+787, Mercy, No Action
+788, Mercy, No Action
+789, Mercy, No Action
+790, Mercy, No Action
+791, Mercy, No Action
+792, Mercy, No Action
+793, Mercy, No Action
+794, Mercy, No Action
+795, Mercy, No Action
+796, Mercy, No Action
+797, Mercy, No Action
+798, Mercy, No Action
+799, Mercy, No Action
+800, Mercy, No Action
+801, Mercy, No Action
+802, Mercy, No Action
+803, Mercy, No Action
+804, Mercy, No Action
+805, Mercy, No Action
+806, Mercy, No Action
+807, Mercy, No Action
+808, Mercy, No Action
+809, Mercy, No Action
+810, Mercy, No Action
+811, Mercy, No Action
+812, Mercy, No Action
+813, Mercy, No Action
+814, Mercy, No Action
+815, Mercy, No Action
+816, Mercy, No Action
+817, Mercy, No Action
+818, Mercy, No Action
+819, Mercy, No Action
+820, Mercy, No Action
+821, Mercy, No Action
+822, Mercy, No Action
+823, Mercy, No Action
+824, Mercy, No Action
+825, Mercy, No Action
+826, Mercy, No Action
+827, Mercy, No Action
+828, Mercy, No Action
+829, Mercy, Firing
+830, Mercy, Firing
+831, Mercy, Firing
+832, Mercy, Firing
+833, Mercy, Firing
+834, Mercy, No Action
+835, Mercy, No Action
+836, Mercy, No Action
+837, Mercy, No Action
+838, Mercy, No Action
+839, Mercy, No Action
+840, Mercy, No Action
+841, Mercy, No Action
+842, Mercy, No Action
+843, Mercy, No Action
+844, Mercy, No Action
+845, Mercy, No Action
+846, Mercy, No Action
+847, Mercy, No Action
+848, Mercy, No Action
+849, Mercy, No Action
+850, Mercy, No Action
+851, Mercy, No Action
+852, Mercy, No Action
+853, Mercy, No Action
+854, Mercy, No Action
+855, Mercy, No Action
+856, Mercy, No Action
+857, Mercy, No Action
+858, Mercy, No Action
+859, Mercy, No Action
+860, Mercy, No Action
+861, Mercy, No Action
+862, Mercy, No Action
+863, Mercy, No Action
+864, Mercy, No Action
+865, Mercy, No Action
+866, Mercy, No Action
+867, Mercy, No Action
+868, Mercy, No Action
+869, Mercy, No Action
+870, Mercy, No Action
+871, Mercy, No Action
+872, Mercy, No Action
+873, Mercy, No Action
+874, Mercy, Firing
+875, Mercy, Firing
+876, Mercy, Firing
+877, Mercy, Firing
+878, Mercy, Firing
+879, Mercy, Firing
+880, Mercy, No Action
+881, Mercy, No Action
+882, Mercy, No Action
+883, Mercy, No Action
+884, Mercy, No Action
+885, Mercy, No Action
+886, Mercy, No Action
+887, Mercy, No Action
+888, Mercy, No Action
+889, Mercy, No Action
+890, Mercy, No Action
+891, Mercy, No Action
+892, Mercy, No Action
+893, Mercy, No Action
+894, Mercy, No Action
+895, Mercy, No Action
+896, Mercy, No Action
+897, Mercy, No Action
+898, Mercy, No Action
+899, Mercy, No Action
+900, Mercy, No Action
+901, Mercy, No Action
+902, Mercy, No Action
+903, Mercy, No Action
+904, Mercy, No Action
+905, Mercy, No Action
+906, Mercy, No Action
+907, Mercy, No Action
+908, Mercy, No Action
+909, Mercy, No Action
+910, Mercy, No Action
+911, Mercy, No Action
+912, Mercy, No Action
+913, Mercy, No Action
+914, Mercy, No Action
+915, Mercy, No Action
+916, Mercy, No Action
+917, Mercy, No Action
+918, Mercy, No Action
+919, Mercy, No Action
+920, Mercy, No Action
+921, Mercy, Firing
+922, Mercy, Firing
+923, Mercy, Firing
+924, Mercy, Firing
+925, Mercy, Firing
+926, Mercy, Firing
+927, Mercy, No Action
+928, Mercy, No Action
+929, Mercy, No Action
+930, Mercy, No Action
+931, Mercy, No Action
+932, Mercy, No Action
+933, Mercy, No Action
+934, Mercy, No Action
+935, Mercy, No Action
+936, Mercy, No Action
+937, Mercy, No Action
+938, Mercy, No Action
+939, Mercy, No Action
+940, Mercy, No Action
+941, Mercy, No Action
+942, Mercy, No Action
+943, Mercy, No Action
+944, Mercy, No Action
+945, Mercy, No Action
+946, Mercy, No Action
+947, Mercy, No Action
+948, Mercy, No Action
+949, Mercy, No Action
+950, Mercy, No Action
+951, Mercy, No Action
+952, Mercy, No Action
+953, Mercy, No Action
+954, Mercy, No Action
+955, Mercy, No Action
+956, Mercy, No Action
+957, Mercy, No Action
+958, Mercy, No Action
+959, Mercy, No Action
+960, Mercy, No Action
+961, Mercy, No Action
+962, Mercy, No Action
+963, Mercy, No Action
+964, Mercy, No Action
+965, Mercy, No Action
+966, Mercy, No Action
+967, Mercy, No Action
+968, Mercy, No Action
+969, Mercy, No Action
+970, Mercy, Firing
+971, Mercy, Firing
+972, Mercy, Firing
+973, Mercy, Firing
+974, Mercy, Firing
+975, Mercy, No Action
+976, Mercy, No Action
+977, Mercy, No Action
+978, Mercy, No Action
+979, Mercy, No Action
+980, Mercy, No Action
+981, Mercy, No Action
+982, Mercy, No Action
+983, Mercy, No Action
+984, Mercy, No Action
+985, Mercy, No Action
+986, Mercy, No Action
+987, Mercy, No Action
+988, Mercy, No Action
+989, Mercy, No Action
+990, Mercy, No Action
+991, Mercy, No Action
+992, Mercy, No Action
+993, Mercy, No Action
+994, Mercy, No Action
+995, Mercy, No Action
+996, Mercy, No Action
+997, Mercy, No Action
+998, Mercy, No Action
+999, Mercy, No Action
+1000, Mercy, No Action
+1001, Mercy, No Action
+1002, Mercy, No Action
+1003, Mercy, No Action
+1004, Mercy, No Action
+1005, Mercy, No Action
+1006, Mercy, No Action
+1007, Mercy, No Action
+1008, Mercy, No Action
+1009, Mercy, No Action
+1010, Mercy, No Action
+1011, Mercy, No Action
+1012, Mercy, No Action
+1013, Mercy, No Action
+1014, Mercy, No Action
+1015, Mercy, No Action
+1016, Mercy, No Action
+1017, Mercy, No Action
+1018, Mercy, No Action
+1019, Mercy, No Action
+1020, Mercy, No Action
+1021, Mercy, No Action
+1022, Mercy, No Action
+1023, Mercy, No Action
+1024, Mercy, No Action
+1025, Mercy, Firing
+1026, Mercy, Firing
+1027, Mercy, Firing
+1028, Mercy, Firing
+1029, Mercy, Firing
+1030, Mercy, No Action
+1031, Mercy, No Action
+1032, Mercy, No Action
+1033, Mercy, No Action
+1034, Mercy, No Action
+1035, Mercy, No Action
+1036, Mercy, No Action
+1037, Mercy, No Action
+1038, Mercy, No Action
+1039, Mercy, No Action
+1040, Mercy, No Action
+1041, Mercy, No Action
+1042, Mercy, No Action
+1043, Mercy, No Action
+1044, Mercy, No Action
+1045, Mercy, No Action
+1046, Mercy, No Action
+1047, Mercy, No Action
+1048, Mercy, No Action
+1049, Mercy, No Action
+1050, Mercy, No Action
+1051, Mercy, No Action
+1052, Mercy, No Action
+1053, Mercy, No Action
+1054, Mercy, No Action
+1055, Mercy, No Action
+1056, Mercy, No Action
+1057, Mercy, No Action
+1058, Mercy, No Action
+1059, Mercy, No Action
+1060, Mercy, No Action
+1061, Mercy, No Action
+1062, Mercy, No Action
+1063, Mercy, No Action
+1064, Mercy, No Action
+1065, Mercy, No Action
+1066, Mercy, No Action
+1067, Mercy, No Action
+1068, Mercy, No Action
+1069, Mercy, No Action
+1070, Mercy, No Action
+1071, Mercy, No Action
+1072, Mercy, No Action
+1073, Mercy, Firing
+1074, Mercy, Firing
+1075, Mercy, Firing
+1076, Mercy, Firing
+1077, Mercy, Firing
+1078, Mercy, No Action
+1079, Mercy, No Action
+1080, Mercy, No Action
+1081, Mercy, No Action
+1082, Mercy, No Action
+1083, Mercy, No Action
+1084, Mercy, No Action
+1085, Mercy, No Action
+1086, Mercy, No Action
+1087, Mercy, No Action
+1088, Mercy, No Action
+1089, Mercy, No Action
+1090, Mercy, No Action
+1091, Mercy, No Action
+1092, Mercy, No Action
+1093, Mercy, No Action
+1094, Mercy, No Action
+1095, Mercy, No Action
+1096, Mercy, No Action
+1097, Mercy, No Action
+1098, Mercy, No Action
+1099, Mercy, No Action
+1100, Mercy, No Action
+1101, Mercy, No Action
+1102, Mercy, No Action
+1103, Mercy, No Action
+1104, Mercy, No Action
+1105, Mercy, No Action
+1106, Mercy, No Action
+1107, Mercy, No Action
+1108, Mercy, No Action
+1109, Mercy, No Action
+1110, Mercy, No Action
+1111, Mercy, No Action
+1112, Mercy, No Action
+1113, Mercy, No Action
+1114, Mercy, No Action
+1115, Mercy, No Action
+1116, Mercy, No Action
+1117, Mercy, No Action
+1118, Mercy, No Action
+1119, Mercy, Firing
+1120, Mercy, Firing
+1121, Mercy, Firing
+1122, Mercy, Firing
+1123, Mercy, Firing
+1124, Mercy, No Action
+1125, Mercy, No Action
+1126, Mercy, No Action
+1127, Mercy, No Action
+1128, Mercy, No Action
+1129, Mercy, No Action
+1130, Mercy, No Action
+1131, Mercy, No Action
+1132, Mercy, No Action
+1133, Mercy, No Action
+1134, Mercy, No Action
+1135, Mercy, No Action
+1136, Mercy, No Action
+1137, Mercy, No Action
+1138, Mercy, No Action
+1139, Mercy, No Action
+1140, Mercy, No Action
+1141, Mercy, No Action
+1142, Mercy, No Action
+1143, Mercy, No Action
+1144, Mercy, No Action
+1145, Mercy, No Action
+1146, Mercy, No Action
+1147, Mercy, No Action
+1148, Mercy, No Action
+1149, Mercy, No Action
+1150, Mercy, No Action
+1151, Mercy, No Action
+1152, Mercy, No Action
+1153, Mercy, No Action
+1154, Mercy, No Action
+1155, Mercy, No Action
+1156, Mercy, No Action
+1157, Mercy, No Action
+1158, Mercy, No Action
+1159, Mercy, No Action
+1160, Mercy, No Action
+1161, Mercy, No Action
+1162, Mercy, No Action
+1163, Mercy, No Action
+1164, Mercy, No Action
+1165, Mercy, No Action
+1166, Mercy, No Action
+1167, Mercy, No Action
+1168, Mercy, Firing
+1169, Mercy, Firing
+1170, Mercy, Firing
+1171, Mercy, Firing
+1172, Mercy, Firing
+1173, Mercy, No Action
+1174, Mercy, No Action
+1175, Mercy, No Action
+1176, Mercy, No Action
+1177, Mercy, No Action
+1178, Mercy, No Action
+1179, Mercy, No Action
+1180, Mercy, No Action
+1181, Mercy, No Action
+1182, Mercy, No Action
+1183, Mercy, No Action
+1184, Mercy, No Action
+1185, Mercy, No Action
+1186, Mercy, No Action
+1187, Mercy, No Action
+1188, Mercy, No Action
+1189, Mercy, No Action
+1190, Mercy, No Action
+1191, Mercy, No Action
+1192, Mercy, No Action
+1193, Mercy, No Action
+1194, Mercy, No Action
+1195, Mercy, No Action
+1196, Mercy, No Action
+1197, Mercy, No Action
+1198, Mercy, No Action
+1199, Mercy, No Action
+1200, Mercy, No Action
+1201, Mercy, No Action
+1202, Mercy, No Action
+1203, Mercy, No Action
+1204, Mercy, No Action
+1205, Mercy, No Action
+1206, Mercy, No Action
+1207, Mercy, No Action
+1208, Mercy, No Action
+1209, Mercy, No Action
+1210, Mercy, No Action
+1211, Mercy, No Action
+1212, Mercy, No Action
+1213, Mercy, No Action
+1214, Mercy, No Action
+1215, Mercy, No Action
+1216, Mercy, No Action
+1217, Mercy, No Action
+1218, Mercy, No Action
+1219, Mercy, No Action
+1220, Mercy, Firing
+1221, Mercy, Firing
+1222, Mercy, Firing
+1223, Mercy, Firing
+1224, Mercy, Firing
+1225, Mercy, No Action
+1226, Mercy, No Action
+1227, Mercy, No Action
+1228, Mercy, No Action
+1229, Mercy, No Action
+1230, Mercy, No Action
+1231, Mercy, No Action
+1232, Mercy, No Action
+1233, Mercy, No Action
+1234, Mercy, No Action
+1235, Mercy, No Action
+1236, Mercy, No Action
+1237, Mercy, No Action
+1238, Mercy, No Action
+1239, Mercy, No Action
+1240, Mercy, No Action
+1241, Mercy, No Action
+1242, Mercy, No Action
+1243, Mercy, No Action
+1244, Mercy, No Action
+1245, Mercy, No Action
+1246, Mercy, No Action
+1247, Mercy, No Action
+1248, Mercy, No Action
+1249, Mercy, No Action
+1250, Mercy, No Action
+1251, Mercy, No Action
+1252, Mercy, No Action
+1253, Mercy, No Action
+1254, Mercy, No Action
+1255, Mercy, No Action
+1256, Mercy, No Action
+1257, Mercy, No Action
+1258, Mercy, No Action
+1259, Mercy, No Action
+1260, Mercy, No Action
+1261, Mercy, No Action
+1262, Mercy, No Action
+1263, Mercy, No Action
+1264, Mercy, No Action
+1265, Mercy, No Action
+1266, Mercy, No Action
+1267, Mercy, No Action
+1268, Mercy, No Action
+1269, Mercy, No Action
+1270, Mercy, No Action
+1271, Mercy, No Action
+1272, Mercy, No Action
+1273, Mercy, No Action
+1274, Mercy, No Action
+1275, Mercy, No Action
+1276, Mercy, Firing
+1277, Mercy, Firing
+1278, Mercy, Firing
+1279, Mercy, Firing
+1280, Mercy, Firing
+1281, Mercy, Firing
+1282, Mercy, No Action
+1283, Mercy, No Action
+1284, Mercy, No Action
+1285, Mercy, No Action
+1286, Mercy, No Action
+1287, Mercy, No Action
+1288, Mercy, No Action
+1289, Mercy, No Action
+1290, Mercy, No Action
+1291, Mercy, No Action
+1292, Mercy, No Action
+1293, Mercy, No Action
+1294, Mercy, No Action
+1295, Mercy, No Action
+1296, Mercy, No Action
+1297, Mercy, No Action
+1298, Mercy, No Action
+1299, Mercy, No Action
+1300, Mercy, No Action
+1301, Mercy, No Action
+1302, Mercy, No Action
+1303, Mercy, No Action
+1304, Mercy, No Action
+1305, Mercy, No Action
+1306, Mercy, No Action
+1307, Mercy, No Action
+1308, Mercy, No Action
+1309, Mercy, No Action
+1310, Mercy, No Action
+1311, Mercy, No Action
+1312, Mercy, No Action
+1313, Mercy, No Action
+1314, Mercy, No Action
+1315, Mercy, No Action
+1316, Mercy, No Action
+1317, Mercy, Firing
+1318, Mercy, Firing
+1319, Mercy, Firing
+1320, Mercy, Firing
+1321, Mercy, Firing
+1322, Mercy, Firing
+1323, Mercy, No Action
+1324, Mercy, No Action
+1325, Mercy, No Action
+1326, Mercy, No Action
+1327, Mercy, No Action
+1328, Mercy, No Action
+1329, Mercy, No Action
+1330, Mercy, No Action
+1331, Mercy, No Action
+1332, Mercy, No Action
+1333, Mercy, No Action
+1334, Mercy, No Action
+1335, Mercy, No Action
+1336, Mercy, No Action
+1337, Mercy, No Action
+1338, Mercy, No Action
+1339, Mercy, No Action
+1340, Mercy, No Action
+1341, Mercy, No Action
+1342, Mercy, No Action
+1343, Mercy, No Action
+1344, Mercy, No Action
+1345, Mercy, No Action
+1346, Mercy, No Action
+1347, Mercy, No Action
+1348, Mercy, No Action
+1349, Mercy, No Action
+1350, Mercy, No Action
+1351, Mercy, No Action
+1352, Mercy, No Action
+1353, Mercy, No Action
+1354, Mercy, No Action
+1355, Mercy, No Action
+1356, Mercy, No Action
+1357, Mercy, No Action
+1358, Mercy, No Action
+1359, Mercy, No Action
+1360, Mercy, Firing
+1361, Mercy, Firing
+1362, Mercy, Firing
+1363, Mercy, Firing
+1364, Mercy, Firing
+1365, Mercy, No Action
+1366, Mercy, No Action
+1367, Mercy, No Action
+1368, Mercy, No Action
+1369, Mercy, No Action
+1370, Mercy, No Action
+1371, Mercy, No Action
+1372, Mercy, No Action
+1373, Mercy, No Action
+1374, Mercy, No Action
+1375, Mercy, No Action
+1376, Mercy, No Action
+1377, Mercy, No Action
+1378, Mercy, No Action
+1379, Mercy, No Action
+1380, Mercy, No Action
+1381, Mercy, No Action
+1382, Mercy, No Action
+1383, Mercy, No Action
+1384, Mercy, No Action
+1385, Mercy, No Action
+1386, Mercy, No Action
+1387, Mercy, No Action
+1388, Mercy, No Action
+1389, Mercy, No Action
+1390, Mercy, No Action
+1391, Mercy, No Action
+1392, Mercy, No Action
+1393, Mercy, No Action
+1394, Mercy, No Action
+1395, Mercy, No Action
+1396, Mercy, No Action
+1397, Mercy, No Action
+1398, Mercy, No Action
+1399, Mercy, No Action
+1400, Mercy, No Action
+1401, Mercy, No Action
+1402, Mercy, No Action
+1403, Mercy, No Action
+1404, Mercy, No Action
+1405, Mercy, No Action
+1406, Mercy, Firing
+1407, Mercy, Firing
+1408, Mercy, Firing
+1409, Mercy, Firing
+1410, Mercy, Firing
+1411, Mercy, No Action
+1412, Mercy, No Action
+1413, Mercy, No Action
+1414, Mercy, No Action
+1415, Mercy, No Action
+1416, Mercy, No Action
+1417, Mercy, No Action
+1418, Mercy, No Action
+1419, Mercy, No Action
+1420, Mercy, No Action
+1421, Mercy, No Action
+1422, Mercy, No Action
+1423, Mercy, No Action
+1424, Mercy, No Action
+1425, Mercy, No Action
+1426, Mercy, No Action
+1427, Mercy, No Action
+1428, Mercy, No Action
+1429, Mercy, No Action
+1430, Mercy, No Action
+1431, Mercy, No Action
+1432, Mercy, No Action
+1433, Mercy, No Action
+1434, Mercy, No Action
+1435, Mercy, No Action
+1436, Mercy, No Action
+1437, Mercy, No Action
+1438, Mercy, No Action
+1439, Mercy, No Action
+1440, Mercy, No Action
+1441, Mercy, No Action
+1442, Mercy, No Action
+1443, Mercy, No Action
+1444, Mercy, No Action
+1445, Mercy, No Action
+1446, Mercy, No Action
+1447, Mercy, No Action
+1448, Mercy, Firing
+1449, Mercy, Firing
+1450, Mercy, Firing
+1451, Mercy, Firing
+1452, Mercy, Firing
+1453, Mercy, No Action
+1454, Mercy, No Action
+1455, Mercy, No Action
+1456, Mercy, No Action
+1457, Mercy, No Action
+1458, Mercy, No Action
+1459, Mercy, No Action
+1460, Mercy, No Action
+1461, Mercy, No Action
+1462, Mercy, No Action
+1463, Mercy, No Action
+1464, Mercy, No Action
+1465, Mercy, No Action
+1466, Mercy, No Action
+1467, Mercy, No Action
+1468, Mercy, No Action
+1469, Mercy, No Action
+1470, Mercy, No Action
+1471, Mercy, No Action
+1472, Mercy, No Action
+1473, Mercy, No Action
+1474, Mercy, No Action
+1475, Mercy, No Action
+1476, Mercy, No Action
+1477, Mercy, No Action
+1478, Mercy, No Action
+1479, Mercy, No Action
+1480, Mercy, No Action
+1481, Mercy, No Action
+1482, Mercy, No Action
+1483, Mercy, No Action
+1484, Mercy, No Action
+1485, Mercy, No Action
+1486, Mercy, No Action
+1487, Mercy, No Action
+1488, Mercy, No Action
+1489, Mercy, No Action
+1490, Mercy, Firing
+1491, Mercy, Firing
+1492, Mercy, Firing
+1493, Mercy, Firing
+1494, Mercy, Firing
+1495, Mercy, No Action
+1496, Mercy, No Action
+1497, Mercy, No Action
+1498, Mercy, No Action
+1499, Mercy, No Action
+1500, Mercy, No Action
+1501, Mercy, No Action
+1502, Mercy, No Action
+1503, Mercy, No Action
+1504, Mercy, No Action
+1505, Mercy, No Action
+1506, Mercy, No Action
+1507, Mercy, No Action
+1508, Mercy, No Action
+1509, Mercy, No Action
+1510, Mercy, No Action
+1511, Mercy, No Action
+1512, Mercy, No Action
+1513, Mercy, No Action
+1514, Mercy, No Action
+1515, Mercy, No Action
+1516, Mercy, No Action
+1517, Mercy, No Action
+1518, Mercy, No Action
+1519, Mercy, No Action
+1520, Mercy, No Action
+1521, Mercy, No Action
+1522, Mercy, No Action
+1523, Mercy, No Action
+1524, Mercy, No Action
+1525, Mercy, No Action
+1526, Mercy, No Action
+1527, Mercy, No Action
+1528, Mercy, No Action
+1529, Mercy, No Action
+1530, Mercy, No Action
+1531, Mercy, No Action
+1532, Mercy, No Action
+1533, Mercy, No Action
+1534, Mercy, No Action
+1535, Mercy, No Action
+1536, Mercy, No Action
+1537, Mercy, No Action
+1538, Mercy, No Action
+1539, Mercy, No Action
+1540, Mercy, No Action
+1541, Mercy, No Action
+1542, Mercy, No Action
+1543, Mercy, No Action
+1544, Mercy, Firing
+1545, Mercy, Firing
+1546, Mercy, Firing
+1547, Mercy, Firing
+1548, Mercy, Firing
+1549, Mercy, No Action
+1550, Mercy, No Action
+1551, Mercy, No Action
+1552, Mercy, No Action
+1553, Mercy, No Action
+1554, Mercy, No Action
+1555, Mercy, No Action
+1556, Mercy, No Action
+1557, Mercy, No Action
+1558, Mercy, No Action
+1559, Mercy, No Action
+1560, Mercy, No Action
+1561, Mercy, No Action
+1562, Mercy, No Action
+1563, Mercy, No Action
+1564, Mercy, No Action
+1565, Mercy, No Action
+1566, Mercy, No Action
+1567, Mercy, No Action
+1568, Mercy, No Action
+1569, Mercy, No Action
+1570, Mercy, No Action
+1571, Mercy, No Action
+1572, Mercy, No Action
+1573, Mercy, No Action
+1574, Mercy, No Action
+1575, Mercy, No Action
+1576, Mercy, No Action
+1577, Mercy, No Action
+1578, Mercy, No Action
+1579, Mercy, No Action
+1580, Mercy, No Action
+1581, Mercy, No Action
+1582, Mercy, No Action
+1583, Mercy, No Action
+1584, Mercy, No Action
+1585, Mercy, No Action
+1586, Mercy, No Action
+1587, Mercy, No Action
+1588, Mercy, No Action
+1589, Mercy, No Action
+1590, Mercy, No Action
+1591, Mercy, No Action
+1592, Mercy, No Action
+1593, Mercy, No Action
+1594, Mercy, Firing
+1595, Mercy, Firing
+1596, Mercy, Firing
+1597, Mercy, Firing
+1598, Mercy, Firing
+1599, Mercy, Firing
+1600, Mercy, No Action
+1601, Mercy, No Action
+1602, Mercy, No Action
+1603, Mercy, No Action
+1604, Mercy, No Action
+1605, Mercy, No Action
+1606, Mercy, No Action
+1607, Mercy, No Action
+1608, Mercy, No Action
+1609, Mercy, No Action
+1610, Mercy, No Action
+1611, Mercy, No Action
+1612, Mercy, No Action
+1613, Mercy, No Action
+1614, Mercy, No Action
+1615, Mercy, No Action
+1616, Mercy, No Action
+1617, Mercy, No Action
+1618, Mercy, No Action
+1619, Mercy, No Action
+1620, Mercy, No Action
+1621, Mercy, No Action
+1622, Mercy, No Action
+1623, Mercy, No Action
+1624, Mercy, No Action
+1625, Mercy, No Action
+1626, Mercy, No Action
+1627, Mercy, No Action
+1628, Mercy, No Action
+1629, Mercy, No Action
+1630, Mercy, No Action
+1631, Mercy, No Action
+1632, Mercy, No Action
+1633, Mercy, No Action
+1634, Mercy, No Action
+1635, Mercy, No Action
+1636, Mercy, No Action
+1637, Mercy, No Action
+1638, Mercy, No Action
+1639, Mercy, No Action
+1640, Mercy, No Action
+1641, Mercy, No Action
+1642, Mercy, No Action
+1643, Mercy, No Action
+1644, Mercy, No Action
+1645, Mercy, No Action
+1646, Mercy, No Action
+1647, Mercy, No Action
+1648, Mercy, No Action
+1649, Mercy, No Action
+1650, Mercy, No Action
+1651, Mercy, No Action
+1652, Mercy, No Action
+1653, Mercy, No Action
+1654, Mercy, No Action
+1655, Mercy, No Action
+1656, Mercy, No Action
+1657, Mercy, No Action
+1658, Mercy, No Action
+1659, Mercy, No Action
+1660, Mercy, No Action
+1661, Mercy, No Action
+1662, Mercy, No Action
+1663, Mercy, No Action
+1664, Mercy, No Action
+1665, Mercy, No Action
+1666, Mercy, No Action
+1667, Mercy, No Action
+1668, Mercy, No Action
+1669, Mercy, No Action
+1670, Mercy, No Action
+1671, Mercy, No Action
+1672, Mercy, No Action
+1673, Mercy, No Action
+1674, Mercy, No Action
+1675, Mercy, No Action
+1676, Mercy, No Action
+1677, Mercy, No Action
+1678, Mercy, No Action
+1679, Mercy, No Action
+1680, Mercy, No Action
+1681, Mercy, No Action
+1682, Mercy, No Action
+1683, Mercy, No Action
+1684, Mercy, No Action
+1685, Mercy, No Action
+1686, Mercy, No Action
+1687, Mercy, No Action
+1688, Mercy, No Action
+1689, Mercy, No Action
+1690, Mercy, No Action
+1691, Mercy, No Action
+1692, Mercy, No Action
+1693, Mercy, No Action
+1694, Mercy, No Action
+1695, Mercy, No Action
+1696, Mercy, No Action
+1697, Mercy, No Action
+1698, Mercy, No Action
+1699, Mercy, No Action
+1700, Mercy, No Action
+1701, Mercy, No Action
+1702, Mercy, No Action
+1703, Mercy, No Action
+1704, Mercy, No Action
+1705, Mercy, No Action
+1706, Mercy, No Action
+1707, Mercy, No Action
+1708, Mercy, No Action
+1709, Mercy, No Action
+1710, Mercy, No Action
+1711, Mercy, No Action
+1712, Mercy, No Action
+1713, Mercy, No Action
+1714, Mercy, Firing
+1715, Mercy, Firing
+1716, Mercy, Firing
+1717, Mercy, Firing
+1718, Mercy, Firing
+1719, Mercy, Firing
+1720, Mercy, No Action
+1721, Mercy, No Action
+1722, Mercy, No Action
+1723, Mercy, No Action
+1724, Mercy, No Action
+1725, Mercy, No Action
+1726, Mercy, No Action
+1727, Mercy, No Action
+1728, Mercy, No Action
+1729, Mercy, No Action
+1730, Mercy, No Action
+1731, Mercy, No Action
+1732, Mercy, No Action
+1733, Mercy, No Action
+1734, Mercy, No Action
+1735, Mercy, No Action
+1736, Mercy, No Action
+1737, Mercy, No Action
+1738, Mercy, No Action
+1739, Mercy, No Action
+1740, Mercy, No Action
+1741, Mercy, No Action
+1742, Mercy, No Action
+1743, Mercy, No Action
+1744, Mercy, No Action
+1745, Mercy, No Action
+1746, Mercy, No Action
+1747, Mercy, No Action
+1748, Mercy, No Action
+1749, Mercy, No Action
+1750, Mercy, No Action
+1751, Mercy, No Action
+1752, Mercy, No Action
+1753, Mercy, No Action
+1754, Mercy, No Action
+1755, Mercy, No Action
+1756, Mercy, No Action
+1757, Mercy, No Action
+1758, Mercy, No Action
+1759, Mercy, No Action
+1760, Mercy, No Action
+1761, Mercy, Firing
+1762, Mercy, Firing
+1763, Mercy, Firing
+1764, Mercy, Firing
+1765, Mercy, Firing
+1766, Mercy, No Action
+1767, Mercy, No Action
+1768, Mercy, No Action
+1769, Mercy, No Action
+1770, Mercy, No Action
+1771, Mercy, No Action
+1772, Mercy, No Action
+1773, Mercy, No Action
+1774, Mercy, No Action
+1775, Mercy, No Action
+1776, Mercy, No Action
+1777, Mercy, No Action
+1778, Mercy, No Action
+1779, Mercy, No Action
+1780, Mercy, No Action
+1781, Mercy, No Action
+1782, Mercy, No Action
+1783, Mercy, No Action
+1784, Mercy, No Action
+1785, Mercy, No Action
+1786, Mercy, No Action
+1787, Mercy, No Action
+1788, Mercy, No Action
+1789, Mercy, No Action
+1790, Mercy, No Action
+1791, Mercy, No Action
+1792, Mercy, No Action
+1793, Mercy, No Action
+1794, Mercy, No Action
+1795, Mercy, No Action
+1796, Mercy, No Action
+1797, Mercy, No Action
+1798, Mercy, No Action
+1799, Mercy, No Action
+1800, Mercy, No Action
+1801, Mercy, No Action
+1802, Mercy, No Action
+1803, Mercy, No Action
+1804, Mercy, No Action
+1805, Mercy, Firing
+1806, Mercy, Firing
+1807, Mercy, Firing
+1808, Mercy, Firing
+1809, Mercy, Firing
+1810, Mercy, No Action
+1811, Mercy, No Action
+1812, Mercy, No Action
+1813, Mercy, No Action
+1814, Mercy, No Action
+1815, Mercy, No Action
+1816, Mercy, No Action
+1817, Mercy, No Action
+1818, Mercy, No Action
+1819, Mercy, No Action
+1820, Mercy, No Action
+1821, Mercy, No Action
+1822, Mercy, No Action
+1823, Mercy, No Action
+1824, Mercy, No Action
+1825, Mercy, No Action
+1826, Mercy, No Action
+1827, Mercy, No Action
+1828, Mercy, No Action
+1829, Mercy, No Action
+1830, Mercy, No Action
+1831, Mercy, No Action
+1832, Mercy, No Action
+1833, Mercy, No Action
+1834, Mercy, No Action
+1835, Mercy, No Action
+1836, Mercy, No Action
+1837, Mercy, No Action
+1838, Mercy, No Action
+1839, Mercy, No Action
+1840, Mercy, No Action
+1841, Mercy, No Action
+1842, Mercy, No Action
+1843, Mercy, No Action
+1844, Mercy, No Action
+1845, Mercy, No Action
+1846, Mercy, No Action
+1847, Mercy, Firing
+1848, Mercy, Firing
+1849, Mercy, Firing
+1850, Mercy, Firing
+1851, Mercy, Firing
+1852, Mercy, No Action
+1853, Mercy, No Action
+1854, Mercy, No Action
+1855, Mercy, No Action
+1856, Mercy, No Action
+1857, Mercy, No Action
+1858, Mercy, No Action
+1859, Mercy, No Action
+1860, Mercy, No Action
+1861, Mercy, No Action
+1862, Mercy, No Action
+1863, Mercy, No Action
+1864, Mercy, No Action
+1865, Mercy, No Action
+1866, Mercy, No Action
+1867, Mercy, No Action
+1868, Mercy, No Action
+1869, Mercy, No Action
+1870, Mercy, No Action
+1871, Mercy, No Action
+1872, Mercy, No Action
+1873, Mercy, No Action
+1874, Mercy, No Action
+1875, Mercy, No Action
+1876, Mercy, No Action
+1877, Mercy, No Action
+1878, Mercy, No Action
+1879, Mercy, No Action
+1880, Mercy, No Action
+1881, Mercy, No Action
+1882, Mercy, No Action
+1883, Mercy, No Action
+1884, Mercy, No Action
+1885, Mercy, No Action
+1886, Mercy, No Action
+1887, Mercy, No Action
+1888, Mercy, No Action
+1889, Mercy, No Action
+1890, Mercy, No Action
+1891, Mercy, No Action
+1892, Mercy, No Action
+1893, Mercy, No Action
+1894, Mercy, No Action
+1895, Mercy, No Action
+1896, Mercy, No Action
+1897, Mercy, No Action
+1898, Mercy, No Action
+1899, Mercy, No Action
+1900, Mercy, No Action
+1901, Mercy, No Action
+1902, Mercy, No Action
+1903, Mercy, No Action
+1904, Mercy, Firing
+1905, Mercy, Firing
+1906, Mercy, Firing
+1907, Mercy, Firing
+1908, Mercy, Firing
+1909, Mercy, No Action
+1910, Mercy, No Action
+1911, Mercy, No Action
+1912, Mercy, No Action
+1913, Mercy, No Action
+1914, Mercy, No Action
+1915, Mercy, No Action
+1916, Mercy, No Action
+1917, Mercy, No Action
+1918, Mercy, No Action
+1919, Mercy, No Action
+1920, Mercy, No Action
+1921, Mercy, No Action
+1922, Mercy, No Action
+1923, Mercy, No Action
+1924, Mercy, No Action
+1925, Mercy, No Action
+1926, Mercy, No Action
+1927, Mercy, No Action
+1928, Mercy, No Action
+1929, Mercy, No Action
+1930, Mercy, No Action
+1931, Mercy, No Action
+1932, Mercy, No Action
+1933, Mercy, No Action
+1934, Mercy, No Action
+1935, Mercy, No Action
+1936, Mercy, No Action
+1937, Mercy, No Action
+1938, Mercy, No Action
+1939, Mercy, No Action
+1940, Mercy, No Action
+1941, Mercy, No Action
+1942, Mercy, No Action
+1943, Mercy, No Action
+1944, Mercy, No Action
+1945, Mercy, No Action
+1946, Mercy, No Action
+1947, Mercy, No Action
+1948, Mercy, No Action
+1949, Mercy, Firing
+1950, Mercy, Firing
+1951, Mercy, Firing
+1952, Mercy, Firing
+1953, Mercy, Firing
+1954, Mercy, No Action
+1955, Mercy, No Action
+1956, Mercy, No Action
+1957, Mercy, No Action
+1958, Mercy, No Action
+1959, Mercy, No Action
+1960, Mercy, No Action
+1961, Mercy, No Action
+1962, Mercy, No Action
+1963, Mercy, No Action
+1964, Mercy, No Action
+1965, Mercy, No Action
+1966, Mercy, No Action
+1967, Mercy, No Action
+1968, Mercy, No Action
+1969, Mercy, No Action
+1970, Mercy, No Action
+1971, Mercy, No Action
+1972, Mercy, No Action
+1973, Mercy, No Action
+1974, Mercy, No Action
+1975, Mercy, No Action
+1976, Mercy, No Action
+1977, Mercy, No Action
+1978, Mercy, No Action
+1979, Mercy, No Action
+1980, Mercy, No Action
+1981, Mercy, No Action
+1982, Mercy, No Action
+1983, Mercy, No Action
+1984, Mercy, No Action
+1985, Mercy, No Action
+1986, Mercy, No Action
+1987, Mercy, No Action
+1988, Mercy, No Action
+1989, Mercy, No Action
+1990, Mercy, No Action
+1991, Mercy, Firing
+1992, Mercy, Firing
+1993, Mercy, Firing
+1994, Mercy, Firing
+1995, Mercy, Firing
+1996, Mercy, Firing
+1997, Mercy, No Action
+1998, Mercy, No Action
+1999, Mercy, No Action
+2000, Mercy, No Action
+2001, Mercy, No Action
+2002, Mercy, No Action
+2003, Mercy, No Action
+2004, Mercy, No Action
+2005, Mercy, No Action
+2006, Mercy, No Action
+2007, Mercy, No Action
+2008, Mercy, No Action
+2009, Mercy, No Action
+2010, Mercy, No Action
+2011, Mercy, No Action
+2012, Mercy, No Action
+2013, Mercy, No Action
+2014, Mercy, No Action
+2015, Mercy, No Action
+2016, Mercy, No Action
+2017, Mercy, No Action
+2018, Mercy, No Action
+2019, Mercy, No Action
+2020, Mercy, No Action
+2021, Mercy, No Action
+2022, Mercy, No Action
+2023, Mercy, No Action
+2024, Mercy, No Action
+2025, Mercy, No Action
+2026, Mercy, No Action
+2027, Mercy, No Action
+2028, Mercy, No Action
+2029, Mercy, No Action
+2030, Mercy, No Action
+2031, Mercy, No Action
+2032, Mercy, No Action
+2033, Mercy, No Action
+2034, Mercy, No Action
+2035, Mercy, No Action
+2036, Mercy, No Action
+2037, Mercy, Firing
+2038, Mercy, Firing
+2039, Mercy, Firing
+2040, Mercy, Firing
+2041, Mercy, Firing
+2042, Mercy, No Action
+2043, Mercy, No Action
+2044, Mercy, No Action
+2045, Mercy, No Action
+2046, Mercy, No Action
+2047, Mercy, No Action
+2048, Mercy, No Action
+2049, Mercy, No Action
+2050, Mercy, No Action
+2051, Mercy, No Action
+2052, Mercy, No Action
+2053, Mercy, No Action
+2054, Mercy, No Action
+2055, Mercy, No Action

--- a/Tools/ground_truth_assessment_tool.cpp
+++ b/Tools/ground_truth_assessment_tool.cpp
@@ -43,9 +43,9 @@ using namespace cv;
 //__________________________________________________________________________________________________
 // Configuration Variables
 
-const string PATH_TO_VIDEO = "Detection_Algorithm/Data/Video/Mercy/Glock/idle.mp4";
+const string PATH_TO_VIDEO = "Detection_Algorithm/Data/Video/Mercy/Glock/firing.mp4";
 const string PATH_TO_METADATA = ""; // Leave this blank to create new
-const string PATH_TO_METADATA_SAVE = "Detection_Algorithm/Data/Output/";
+const string PATH_TO_METADATA_SAVE = "Detection_Algorithm/Data/Output";
 
 // These are the weapon actions assigned by the number keys 1-5
 // If a hero other than Mercy is being analyzed, these may need to be changed

--- a/Tools/ground_truth_assessment_tool.cpp
+++ b/Tools/ground_truth_assessment_tool.cpp
@@ -6,11 +6,10 @@
  * extract desired frames, or assess the accuracy of an object detection method by comparing
  * against the ground truth.
  *
- * This program takes a single video path as input. It will automatically check the MetaData
- * directory to see if a corresponding .meta file exists.
- *
- * - If a metadata file exists, it will be opened so that it can be edited
- * - If no file exists, a new file will be created initialized to No_Hero, and No_Action
+ * This program takes a single video path as input. If the PATH_TO_METADATA string is empty, the
+ * metadata file will be created from scratch. Otherwise the metadata file will be opened at the
+ * provided path. The metadata file will be saved to PATH_TO_METADATA_SAVE. This can be the same
+ * as PATH_TO_METADATA to overwrite changes.
  *
  * Once a MetaFile has been created, the user will be able to step through each frame in the video.
  * _________________________________________________________________________________________________
@@ -45,7 +44,8 @@ using namespace cv;
 // Configuration Variables
 
 const string PATH_TO_VIDEO = "Detection_Algorithm/Data/Video/Mercy/Glock/idle.mp4";
-const string PATH_TO_METADATA = "Detection_Algorithm/Data/MetaData";
+const string PATH_TO_METADATA = ""; // Leave this blank to create new
+const string PATH_TO_METADATA_SAVE = "Detection_Algorithm/Data/Output/";
 
 // These are the weapon actions assigned by the number keys 1-5
 // If a hero other than Mercy is being analyzed, these may need to be changed
@@ -94,25 +94,14 @@ int main()
     string filePath = PATH_TO_VIDEO;
     string filename = removePath(filePath);
     MetaFile metaFile;
-    bool matchFound = false;
 
-    // Search for corresponding metadata files in the MetaData directory
-    for (const auto & file : std::__fs::filesystem::directory_iterator(PATH_TO_METADATA))
+    if(!PATH_TO_METADATA.empty())
     {
-        string nextFile = removePath(file.path());
+        metaFile = MetaFile(PATH_TO_METADATA);
 
-        if(nextFile == filename)
-        {
-            cout << "Matching metadata file found, opening file" << endl;
-
-            metaFile = MetaFile(file.path());
-            matchFound = true;
-            break;
-        }
+        cout << "Opened " << PATH_TO_METADATA << endl;
     }
-
-    // Create a meta file from scratch if none has been found
-    if(!matchFound)
+    else
     {
         cout << "No corresponding meta file found, creating from scratch" << endl;
 
@@ -133,11 +122,11 @@ int main()
 
     cout << "Frame loop complete, saving metafile" << endl;
 
-    string metaFileName = PATH_TO_METADATA + "/" + filename + ".meta";
+    string metaFileName = PATH_TO_METADATA_SAVE + "/" + filename + ".meta";
 
     metaFile.save(metaFileName);
 
-    cout << "Meta File Saved" << endl;
+    cout << "Meta File Saved at " << metaFileName << endl;
 
     return 0;
 }


### PR DESCRIPTION
This removes the automatic metafile file search / creation in favor of manual open/save paths. This fixes our Windows/Unix compatibility issues and also gets around some problems with the gitignore we were going to run into. Metafile generation is tedious and takes awhile, a small amount of file management isn't going to make it any worse.